### PR TITLE
Mark unfixed clippy warnings as allowed

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
@@ -156,8 +156,8 @@ impl Cgroup for CgroupV1 {
         }
 
         self.controllers
-            .iter()
-            .map(|(kind, _subsys)| {
+            .keys()
+            .map(|kind| {
                 if kind == "cpuset" {
                     return Ok(());
                 }

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
@@ -244,8 +244,7 @@ impl Cgroup for CgroupV2 {
             if let Some(weight) = blkio.weight() {
                 if weight != 0 {
                     // Use BFQ
-                    if let Err(_) =
-                        ensure_write_file(self.get_file(IO_BFQ_WEIGHT)?, &format!("{}", weight))
+                    if ensure_write_file(self.get_file(IO_BFQ_WEIGHT)?, &format!("{}", weight)).is_err()
                     {
                         // Fallback to io.weight with a conversion scheme
                         ensure_write_file(

--- a/crates/containerd-shim-wasm/src/sandbox/exec.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/exec.rs
@@ -143,6 +143,7 @@ pub fn has_cap_sys_admin() -> bool {
 /// Code that runs in the child must not do things like access locks or other shared state.
 /// The child should not depend on other threads in the parent process since the new process becomes single threaded.
 ///
+/// # Safety
 /// This is marked as unsafe because this can effect things like mutex locks or other previously shared state which is no longer shared (with the child process) after the fork.
 pub unsafe fn fork(cgroup: Option<&dyn Cgroup>) -> Result<Context, Error> {
     let mut builder = Clone3::default();

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -963,7 +963,7 @@ where
 
         // Per the spec, the prestart hook must be called as part of the create operation
         debug!("call prehook before the start");
-        oci::setup_prestart_hooks(&spec.hooks())?;
+        oci::setup_prestart_hooks(spec.hooks())?;
 
         Ok(api::CreateTaskResponse {
             pid: std::process::id(),
@@ -1286,7 +1286,7 @@ fn setup_namespaces(spec: &runtime::Spec) -> Result<()> {
     for ns in namespaces {
         if ns.typ() == runtime::LinuxNamespaceType::Network {
             if let Some(p) = ns.path() {
-                let f = File::open(&p).map_err(|err| {
+                let f = File::open(p).map_err(|err| {
                     ShimError::Other(format!(
                         "could not open network namespace {}: {}",
                         p.display(),

--- a/crates/containerd-shim-wasm/src/services/sandbox_ttrpc.rs
+++ b/crates/containerd-shim-wasm/src/services/sandbox_ttrpc.rs
@@ -27,6 +27,7 @@ pub struct ManagerClient {
 }
 
 impl ManagerClient {
+    #[allow(clippy::redundant_field_names)]
     pub fn new(client: ::ttrpc::Client) -> Self {
         ManagerClient {
             client: client,

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -131,29 +131,29 @@ pub fn prepare_module(
     );
 
     debug!("opening stdin");
-    let stdin = maybe_open_stdio(&stdin_path).context("could not open stdin")?;
-    if stdin.is_some() {
+    let maybe_stdin = maybe_open_stdio(&stdin_path).context("could not open stdin")?;
+    if let Some(stdin) = maybe_stdin {
         unsafe {
             STDIN_FD = Some(dup(STDIN_FILENO));
-            dup2(stdin.unwrap(), STDIN_FILENO);
+            dup2(stdin, STDIN_FILENO);
         }
     }
 
     debug!("opening stdout");
-    let stdout = maybe_open_stdio(&stdout_path).context("could not open stdout")?;
-    if stdout.is_some() {
+    let maybe_stdout = maybe_open_stdio(&stdout_path).context("could not open stdout")?;
+    if let Some(stdout) = maybe_stdout {
         unsafe {
             STDOUT_FD = Some(dup(STDOUT_FILENO));
-            dup2(stdout.unwrap(), STDOUT_FILENO);
+            dup2(stdout, STDOUT_FILENO);
         }
     }
 
     debug!("opening stderr");
-    let stderr = maybe_open_stdio(&stderr_path).context("could not open stderr")?;
-    if stderr.is_some() {
+    let maybe_stderr = maybe_open_stdio(&stderr_path).context("could not open stderr")?;
+    if let Some(stderr) = maybe_stderr {
         unsafe {
             STDERR_FD = Some(dup(STDERR_FILENO));
-            dup2(stderr.unwrap(), STDERR_FILENO);
+            dup2(stderr, STDERR_FILENO);
         }
     }
 
@@ -235,7 +235,7 @@ impl Instance for Wasi {
 
                 // TODO: How to get exit code?
                 // This was relatively straight forward in go, but wasi and wasmtime are totally separate things in rust.
-                let _ret = match vm.run_func(Some("main"), "_start", params!()) {
+                match vm.run_func(Some("main"), "_start", params!()) {
                     Ok(_) => std::process::exit(0),
                     Err(_) => std::process::exit(137),
                 };
@@ -255,7 +255,7 @@ impl Instance for Wasi {
         let fd = lr
             .as_ref()
             .ok_or_else(|| Error::FailedPrecondition("module is not running".to_string()))?;
-        fd.kill(SIGKILL as i32)
+        fd.kill(SIGKILL)
     }
 
     fn delete(&self) -> Result<(), Error> {

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -221,7 +221,7 @@ impl Instance for Wasi {
 
                 // TODO: How to get exit code?
                 // This was relatively straight forward in go, but wasi and wasmtime are totally separate things in rust.
-                let _ret = match f.call(&mut store, &[], &mut []) {
+                match f.call(&mut store, &[], &mut []) {
                     Ok(_) => std::process::exit(0),
                     Err(_) => std::process::exit(137),
                 };

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -83,7 +83,7 @@ impl Builder {
 
             let mut th = tar::Header::new_gnu();
             th.set_mode(0o444);
-            th.set_size(meta.len() as u64);
+            th.set_size(meta.len());
             let p = "blobs/sha256/".to_owned() + &dgst;
             th.set_path(&p).context("could not set path for layer")?;
             th.set_cksum();


### PR DESCRIPTION
The idea is that we'll catch new errors in CI and also we can fix the existing warnings whenever we like.