### PR TITLE
Last clippy fixes.

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
@@ -331,7 +331,7 @@ pub mod tests {
         format!("{}{}", prefix, rand::random::<u32>())
     }
 
-    fn cgroup_test(cg: Box<&dyn Cgroup>) -> Result<()> {
+    fn cgroup_test(cg: &dyn Cgroup) -> Result<()> {
         let s: Spec = json::from_str(
             r#"
         {
@@ -373,7 +373,7 @@ pub mod tests {
 
         debug!("cgroup: {}", cg.version());
 
-        cgroup_test(Box::new(&cg)).unwrap();
+        cgroup_test(&cg).unwrap();
         if cg.version() == Version::V2 {
             let fd = cg.open()?;
             nix::unistd::close(fd)?;
@@ -385,7 +385,7 @@ pub mod tests {
         );
         cg.delete_all()?;
 
-        cgroup_test(Box::new(&cg)).unwrap();
+        cgroup_test(&cg).unwrap();
         if cg.version() == Version::V2 {
             let fd = cg.open()?;
             nix::unistd::close(fd)?;
@@ -396,7 +396,7 @@ pub mod tests {
             generate_random("/absolute") + "/nested/containerd-wasm-shim-test_cgroup",
         );
         cg.delete_all()?;
-        cgroup_test(Box::new(&cg)).unwrap();
+        cgroup_test(&cg).unwrap();
         if cg.version() == Version::V2 {
             let fd = cg.open()?;
             nix::unistd::close(fd)?;

--- a/crates/containerd-shim-wasm/src/sandbox/exec.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/exec.rs
@@ -233,7 +233,7 @@ mod tests {
         match ret {
             Ok(Context::Parent(tid, pidfd)) => {
                 // Make sure the child has setup signal handlers
-                let res = read(r, &mut vec![0]);
+                let res = read(r, &mut [0]);
                 _ = close(r);
                 res.unwrap();
 

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -391,7 +391,7 @@ mod wasitest {
                 )));
             }
         };
-        return res;
+        res
     }
 
     #[test]


### PR DESCRIPTION
This should now pass also with `cargo clippy --all --all-targets -- -D warnings`.